### PR TITLE
Add option to add deb dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,11 +70,12 @@ jobs:
       - uses: jiro4989/setup-nim-action@v1
       - run: |
           git clone https://github.com/jiro4989/nimjson app
-          pushd app
-          nimble build -Y
-          cp bin/nimjson ../
+          (
+            cd app
+            nimble build -Y
+            cp bin/nimjson ../
+          )
           rm -rf app
-          popd
 
           mkdir -p .debpkg/usr/bin
           mv nimjson .debpkg/usr/bin/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
           package_root: .debpkg
           maintainer: jiro4989
           version: 'v1.0.0'
-          depends: 'libc6: (>= 2.2.1)'
+          depends: 'libc6 (>= 2.2.1), git'
           arch: 'amd64'
           desc: 'test package'
       - run: sudo dpkg -i *.deb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
       - run: sudo dpkg -i *.deb
       - run: which nimjson
       - run: nimjson -h
+      - run: dpkg -s nimjson
 
   test-postinst:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
           package_root: .debpkg
           maintainer: jiro4989
           version: 'v1.0.0'
-          depends: 'libc6 (>= 2.2.1), default-mta | mail-transport-agent'
+          depends: 'libc6: (>= 2.2.1)'
           arch: 'amd64'
           desc: 'test package'
       - run: sudo dpkg -i *.deb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,4 +128,30 @@ jobs:
           testbin2
           find /usr/lib/testbin/
           cat /usr/lib/testbin/testbin.conf
+  test-depends:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jiro4989/setup-nim-action@v1
+      - run: |
+          git clone https://github.com/jiro4989/nimjson app
+          pushd app
+          nimble build -Y
+          cp bin/nimjson ../
+          rm -rf app
+          popd
 
+          mkdir -p .debpkg/usr/bin
+          mv nimjson .debpkg/usr/bin/
+      - uses: ./
+        with:
+          package: nimjson
+          package_root: .debpkg
+          maintainer: jiro4989
+          version: 'v1.0.0'
+          depends: 'libc6 (>= 2.2.1), default-mta | mail-transport-agent'
+          arch: 'amd64'
+          desc: 'test package'
+      - run: sudo dpkg -i *.deb
+      - run: which nimjson
+      - run: nimjson -h

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,7 @@ jobs:
           testbin2
           find /usr/lib/testbin/
           cat /usr/lib/testbin/testbin.conf
+
   test-depends:
     runs-on: ubuntu-latest
     steps:
@@ -137,11 +138,12 @@ jobs:
       - uses: jiro4989/setup-nim-action@v1
       - run: |
           git clone https://github.com/jiro4989/nimjson app
-          pushd app
-          nimble build -Y
-          cp bin/nimjson ../
+          (
+            cd app
+            nimble build -Y
+            cp bin/nimjson ../
+          )
           rm -rf app
-          popd
 
           mkdir -p .debpkg/usr/bin
           mv nimjson .debpkg/usr/bin/
@@ -157,3 +159,4 @@ jobs:
       - run: sudo dpkg -i *.deb
       - run: which nimjson
       - run: nimjson -h
+      - run: dpkg -s nimjson

--- a/README.md
+++ b/README.md
@@ -27,12 +27,18 @@ inputs:
   version:
     description: 'Package version.'
     required: true
+  depends:
+    description: 'Package dependencies.'
+    default: 'none'
+    required: false
   arch:
     description: 'Package architecture.'
     default: 'amd64'
+    required: false
   desc:
     description: 'Package description.'
     default: ''
+    required: false
 ```
 
 ## Usage
@@ -65,6 +71,7 @@ jobs:
           maintainer: your_name
           version: ${{ github.ref }} # refs/tags/v*.*.*
           arch: 'amd64'
+          depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,18 @@ inputs:
   version:
     description: 'Package version.'
     required: true
+  depends:
+    description: 'Package dependencies.'
+    default: ''
+    required: false
   arch:
     description: 'Package architecture.'
     default: 'amd64'
+    required: false
   desc:
     description: 'Package description.'
     default: ''
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
   depends:
     description: 'Package dependencies.'
-    default: ''
+    default: 'none'
     required: false
   arch:
     description: 'Package architecture.'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
   --debian-dir:/template/DEBIAN \
   --package:"$INPUT_PACKAGE" \
   --version:"$INPUT_VERSION" \
+  --depends:"$INPUT_DEPENDS" \
   --arch:"$INPUT_ARCH" \
   --maintainer:"$INPUT_MAINTAINER" \
   --description:"$INPUT_DESC"

--- a/template/DEBIAN/control
+++ b/template/DEBIAN/control
@@ -2,5 +2,5 @@ Package: PACKAGE
 Version: VERSION
 Architecture: ARCH
 Maintainer: MAINTAINER
-Depends: DEPENDS
+DEPENDS
 DESC

--- a/template/DEBIAN/control
+++ b/template/DEBIAN/control
@@ -2,4 +2,5 @@ Package: PACKAGE
 Version: VERSION
 Architecture: ARCH
 Maintainer: MAINTAINER
+Depends: DEPENDS
 DESC

--- a/template/DEBIAN/control
+++ b/template/DEBIAN/control
@@ -1,6 +1,5 @@
-Package: PACKAGE
-Version: VERSION
-Architecture: ARCH
-Maintainer: MAINTAINER
-DEPENDS
-DESC
+Package: {PACKAGE}
+Version: {VERSION}
+Architecture: {ARCH}
+Maintainer: {MAINTAINER}
+{DEPENDS}{DESC}

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -32,18 +32,18 @@ proc getCmdOpts(params: seq[string]): Options =
 proc replaceTemplate(body, package, maintainer, version, arch, depends, desc: string): string =
   result =
     body
-      .replace("PACKAGE", package)
-      .replace("MAINTAINER", maintainer)
-      .replace("VERSION", version)
-      .replace("ARCH", arch)
-      .replace("DEPENDS", depends)
-      .replace("DESC", desc)
+      .replace("{PACKAGE}", package)
+      .replace("{MAINTAINER}", maintainer)
+      .replace("{VERSION}", version)
+      .replace("{ARCH}", arch)
+      .replace("{DEPENDS}", depends)
+      .replace("{DESC}", desc)
 
 proc formatDescription(desc: string): string =
   "Description: " & desc
 
 proc formatDepends(depends: string): string =
-  if depends != "none": "Depends: " & depends else: ""
+  if depends != "none": "Depends: " & depends & "\n" else: ""
 
 proc fixFile(file, package, maintainer, version, arch, depends, desc: string) =
   let

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -29,24 +29,27 @@ proc getCmdOpts(params: seq[string]): Options =
     else:
       assert false
 
-proc replaceTemplate(body, package, maintainer, version, depends, arch, desc: string): string =
+proc replaceTemplate(body, package, maintainer, version, arch, depends, desc: string): string =
   result =
     body
       .replace("PACKAGE", package)
       .replace("MAINTAINER", maintainer)
       .replace("VERSION", version)
-      .replace("DEPENDS", depends)
       .replace("ARCH", arch)
+      .replace("DEPENDS", depends)
       .replace("DESC", desc)
 
 proc formatDescription(desc: string): string =
   "Description: " & desc
 
-proc fixFile(file, package, maintainer, version, depends, arch, desc: string) =
+proc formatDepends(depends: string): string =
+  if depends != "none": "Depends: " & depends else: ""
+
+proc fixFile(file, package, maintainer, version, arch, depends, desc: string) =
   let
     body = readFile(file)
     fixedBody = replaceTemplate(body, package=package, maintainer=maintainer,
-                                version=version, depends=depends, arch=arch, desc=desc)
+                                version=version, arch=arch, depends=depends, desc=desc)
   writeFile(file, fixedBody)
 
 let
@@ -58,9 +61,9 @@ let
   package = params.package
   maintainer = params.maintainer
   version = params.version.strip(trailing = false, chars = {'v'})
-  depends = params.depends
   arch = params.arch
+  depends = params.depends.formatDepends
   desc = params.desc.formatDescription
 
 fixFile(controlFile, package=package, maintainer=maintainer, version=version,
-        depends=depends, arch=arch, desc=desc)
+        arch=arch, depends=depends, desc=desc)

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -2,7 +2,7 @@ import os, strutils, parseopt
 
 type
   Options = object
-    debianDir, package, maintainer, version, arch, desc: string
+    debianDir, package, maintainer, version, depends, arch, desc: string
 
 proc getCmdOpts(params: seq[string]): Options =
   var optParser = initOptParser(params)
@@ -18,6 +18,8 @@ proc getCmdOpts(params: seq[string]): Options =
         result.maintainer = val
       of "version":
         result.version = val
+      of "depends":
+        result.depends = val
       of "arch":
         result.arch = val
       of "description":
@@ -27,23 +29,24 @@ proc getCmdOpts(params: seq[string]): Options =
     else:
       assert false
 
-proc replaceTemplate(body, package, maintainer, version, arch, desc: string): string =
+proc replaceTemplate(body, package, maintainer, version, depends, arch, desc: string): string =
   result =
     body
       .replace("PACKAGE", package)
       .replace("MAINTAINER", maintainer)
       .replace("VERSION", version)
+      .replace("DEPENDS", depends)
       .replace("ARCH", arch)
       .replace("DESC", desc)
 
 proc formatDescription(desc: string): string =
   "Description: " & desc
 
-proc fixFile(file, package, maintainer, version, arch, desc: string) =
+proc fixFile(file, package, maintainer, version, depends, arch, desc: string) =
   let
     body = readFile(file)
     fixedBody = replaceTemplate(body, package=package, maintainer=maintainer,
-                                version=version, arch=arch, desc=desc)
+                                version=version, depends=depends, arch=arch, desc=desc)
   writeFile(file, fixedBody)
 
 let
@@ -55,7 +58,9 @@ let
   package = params.package
   maintainer = params.maintainer
   version = params.version.strip(trailing = false, chars = {'v'})
+  depends = params.depends
   arch = params.arch
   desc = params.desc.formatDescription
 
-fixFile(controlFile, package=package, maintainer=maintainer, version=version, arch=arch, desc=desc)
+fixFile(controlFile, package=package, maintainer=maintainer, version=version,
+        depends=depends, arch=arch, desc=desc)

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -43,7 +43,11 @@ proc formatDescription(desc: string): string =
   "Description: " & desc
 
 proc formatDepends(depends: string): string =
-  if depends != "none": "Depends: " & depends & "\n" else: ""
+  result =
+    if depends != "none":
+      "Depends: " & depends & "\n"
+    else:
+      ""
 
 proc fixFile(file, package, maintainer, version, arch, depends, desc: string) =
   let


### PR DESCRIPTION
Added optional `Depends: ` field to add other packages dependencies.

As the parser didn't seem to like empty string `"none"` is passed in no dependencies are needed.

_As I have no experience with `nim`, feel free to point out / fix wherever something could be written better._