### PR TITLE
added support for 'Installed-Size' field in deb package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,13 @@ jobs:
           depends: 'libc6 (>= 2.2.1), git'
           arch: 'amd64'
           desc: 'test package'
-      - run: sudo dpkg -i *.deb
-      - run: which nimjson
-      - run: nimjson -h
-      - run: dpkg -s nimjson
+      - name: Install deb package
+        run: sudo dpkg -i ./*.deb
+      - name: Print deb package information
+        run: dpkg -I ./*.deb
+      - name: Print installed command path
+        run: which nimjson
+      - name: Print command help message
+        run: nimjson -h
+      - name: Print installed deb package information
+        run: dpkg -s nimjson

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: install deb package
         run: sudo dpkg -i *.deb
+      - name: Print deb package information
+        run: dpkg -I ./*.deb
       - name: check files
         run: |
           which testbin
@@ -55,6 +57,11 @@ jobs:
           testbin2
           find /usr/lib/testbin/
           cat /usr/lib/testbin/testbin.conf
+      - name: Print installed deb package size
+        run: >
+          dpkg-query -W -f='${Installed-Size}\t${Package}\n' |
+          sort -nr |
+          grep nimjson
 
   test-github-ref-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,3 +189,8 @@ jobs:
         run: nimjson -h
       - name: Print installed deb package information
         run: dpkg -s nimjson
+      - name: Print installed deb package size
+        run: >
+          dpkg-query -W -f='${Installed-Size}\t${Package}\n' |
+          sort -nr |
+          grep nimjson

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         run: >
           dpkg-query -W -f='${Installed-Size}\t${Package}\n' |
           sort -nr |
-          grep nimjson
+          grep testbin
 
   test-github-ref-version:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ inputs:
   version:
     description: 'Package version.'
     required: true
+  size:
+    description: 'Package installed size.'
+    default: ''
+    required: false
   depends:
     description: 'Package dependencies.'
     default: 'none'

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ inputs:
   version:
     description: 'Package version.'
     required: true
-  size:
-    description: 'Package installed size.'
+  installed_size:
+    description: 'Package installed size. GitHub Actions set summarized byte size of `package_root` directory when this parameter is empty.'
     default: ''
     required: false
   depends:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: Dockerfile
+  image: 'docker://jiro4989/build-deb-action:2.4.0'
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 # TODO: update branding if you want.

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://jiro4989/build-deb-action:2.4.0'
+  image: Dockerfile
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 # TODO: update branding if you want.

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   version:
     description: 'Package version.'
     required: true
+  size:
+    description: 'Package installed size.'
+    default: ''
+    required: false
   depends:
     description: 'Package dependencies.'
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'Package version.'
     required: true
   installed_size:
-    description: 'Package installed size.'
+    description: 'Package installed size. GitHub Actions set summarized byte size of `package_root` directory when this parameter is empty.'
     default: ''
     required: false
   depends:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  # image: 'docker://jiro4989/build-deb-action:2.4.0'
+  image: 'docker://jiro4989/build-deb-action:2.4.0'
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 # TODO: update branding if you want.

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://jiro4989/build-deb-action:2.4.0'
+  # image: 'docker://jiro4989/build-deb-action:2.4.0'
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 # TODO: update branding if you want.

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   version:
     description: 'Package version.'
     required: true
-  size:
+  installed_size:
     description: 'Package installed size.'
     default: ''
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,16 +4,16 @@ set -eux
 
 INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
-if [ -z "$INPUT_SIZE" ]; then
+if [ -z "$INPUT_INSTALLED_SIZE" ]; then
   PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | awk '{print $1}' | head -1 | sed -e 's/^0\+//')"
-  INPUT_SIZE="$(awk -v size="$PACKAGE_ROOT_SIZE_BYTES" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}')"
+  INPUT_INSTALLED_SIZE="$(awk -v size="$PACKAGE_ROOT_SIZE_BYTES" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}')"
 fi
 
 /replacetool \
   --debian-dir:/template/DEBIAN \
   --package:"$INPUT_PACKAGE" \
   --version:"$INPUT_VERSION" \
-  --size:"$INPUT_SIZE" \
+  --installed-size:"$INPUT_INSTALLED_SIZE" \
   --depends:"$INPUT_DEPENDS" \
   --arch:"$INPUT_ARCH" \
   --maintainer:"$INPUT_MAINTAINER" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
 if [ -z "$INPUT_SIZE" ]; then
   PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | awk '{print $1}' | head -1 | sed -e 's/^0\+//')"
-  INPUT_SIZE="$(awk "BEGIN {print ($PACKAGE_ROOT_SIZE_BYTES/1024)+1}" | awk '{print int($0)}')"
+  INPUT_SIZE="$(awk -v size="$PACKAGE_ROOT_SIZE_BYTES" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}')"
 fi
 
 /replacetool \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -eux
 INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
 if [ -z "$INPUT_SIZE" ]; then
-  PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')"
+  PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | awk '{print $1}' | head -1 | sed -e 's/^0\+//')"
   INPUT_SIZE="$(awk "BEGIN {print ($PACKAGE_ROOT_SIZE_BYTES/1024)+1}" | awk '{print int($0)}')"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,16 @@ set -eux
 
 INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
+if [ -z "$INPUT_SIZE" ]; then
+  PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN $INPUT_PACKAGE_ROOT/ | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')"
+  INPUT_SIZE="$(awk "BEGIN {print ($PACKAGE_ROOT_SIZE_BYTES/1024)+1}" | awk '{print int($0)}')"
+fi
+
 /replacetool \
   --debian-dir:/template/DEBIAN \
   --package:"$INPUT_PACKAGE" \
   --version:"$INPUT_VERSION" \
+  --size:"$INPUT_SIZE" \
   --depends:"$INPUT_DEPENDS" \
   --arch:"$INPUT_ARCH" \
   --maintainer:"$INPUT_MAINTAINER" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -eux
 INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
 if [ -z "$INPUT_SIZE" ]; then
-  PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN $INPUT_PACKAGE_ROOT/ | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')"
+  PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')"
   INPUT_SIZE="$(awk "BEGIN {print ($PACKAGE_ROOT_SIZE_BYTES/1024)+1}" | awk '{print int($0)}')"
 fi
 

--- a/template/DEBIAN/control
+++ b/template/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: {PACKAGE}
 Version: {VERSION}
-Installed-Size: {SIZE}
+Installed-Size: {INSTALLED_SIZE}
 Architecture: {ARCH}
 Maintainer: {MAINTAINER}
 {DEPENDS}{DESC}

--- a/template/DEBIAN/control
+++ b/template/DEBIAN/control
@@ -1,5 +1,6 @@
 Package: {PACKAGE}
 Version: {VERSION}
+Installed-Size: {SIZE}
 Architecture: {ARCH}
 Maintainer: {MAINTAINER}
 {DEPENDS}{DESC}

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -2,7 +2,7 @@ import os, strutils, parseopt
 
 type
   Options = object
-    debianDir, package, maintainer, version, depends, arch, desc: string
+    debianDir, package, maintainer, version, size, depends, arch, desc: string
 
 proc getCmdOpts(params: seq[string]): Options =
   var optParser = initOptParser(params)
@@ -18,6 +18,8 @@ proc getCmdOpts(params: seq[string]): Options =
         result.maintainer = val
       of "version":
         result.version = val
+      of "size":
+        result.size = val
       of "depends":
         result.depends = val
       of "arch":
@@ -29,12 +31,13 @@ proc getCmdOpts(params: seq[string]): Options =
     else:
       assert false
 
-proc replaceTemplate(body, package, maintainer, version, arch, depends, desc: string): string =
+proc replaceTemplate(body, package, maintainer, version, size, arch, depends, desc: string): string =
   result =
     body
       .replace("{PACKAGE}", package)
       .replace("{MAINTAINER}", maintainer)
       .replace("{VERSION}", version)
+      .replace("{SIZE}", size)
       .replace("{ARCH}", arch)
       .replace("{DEPENDS}", depends)
       .replace("{DESC}", desc)
@@ -49,11 +52,11 @@ proc formatDepends(depends: string): string =
     else:
       ""
 
-proc fixFile(file, package, maintainer, version, arch, depends, desc: string) =
+proc fixFile(file, package, maintainer, version, size, arch, depends, desc: string) =
   let
     body = readFile(file)
     fixedBody = replaceTemplate(body, package=package, maintainer=maintainer,
-                                version=version, arch=arch, depends=depends, desc=desc)
+                                version=version, size=size, arch=arch, depends=depends, desc=desc)
   writeFile(file, fixedBody)
 
 let
@@ -65,9 +68,10 @@ let
   package = params.package
   maintainer = params.maintainer
   version = params.version.strip(trailing = false, chars = {'v'})
+  size = params.size
   arch = params.arch
   depends = params.depends.formatDepends
   desc = params.desc.formatDescription
 
 fixFile(controlFile, package=package, maintainer=maintainer, version=version,
-        arch=arch, depends=depends, desc=desc)
+        size=size, arch=arch, depends=depends, desc=desc)

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -2,7 +2,7 @@ import os, strutils, parseopt
 
 type
   Options = object
-    debianDir, package, maintainer, version, size, depends, arch, desc: string
+    debianDir, package, maintainer, version, installedSize, depends, arch, desc: string
 
 proc getCmdOpts(params: seq[string]): Options =
   var optParser = initOptParser(params)
@@ -18,8 +18,8 @@ proc getCmdOpts(params: seq[string]): Options =
         result.maintainer = val
       of "version":
         result.version = val
-      of "size":
-        result.size = val
+      of "installed-size":
+        result.installedSize = val
       of "depends":
         result.depends = val
       of "arch":
@@ -31,13 +31,13 @@ proc getCmdOpts(params: seq[string]): Options =
     else:
       assert false
 
-proc replaceTemplate(body, package, maintainer, version, size, arch, depends, desc: string): string =
+proc replaceTemplate(body, package, maintainer, version, installedSize, arch, depends, desc: string): string =
   result =
     body
       .replace("{PACKAGE}", package)
       .replace("{MAINTAINER}", maintainer)
       .replace("{VERSION}", version)
-      .replace("{SIZE}", size)
+      .replace("{INSTALLED_SIZE}", installedSize)
       .replace("{ARCH}", arch)
       .replace("{DEPENDS}", depends)
       .replace("{DESC}", desc)
@@ -52,11 +52,11 @@ proc formatDepends(depends: string): string =
     else:
       ""
 
-proc fixFile(file, package, maintainer, version, size, arch, depends, desc: string) =
+proc fixFile(file, package, maintainer, version, installedSize, arch, depends, desc: string) =
   let
     body = readFile(file)
     fixedBody = replaceTemplate(body, package=package, maintainer=maintainer,
-                                version=version, size=size, arch=arch, depends=depends, desc=desc)
+                                version=version, installedSize=installedSize, arch=arch, depends=depends, desc=desc)
   writeFile(file, fixedBody)
 
 let
@@ -68,10 +68,10 @@ let
   package = params.package
   maintainer = params.maintainer
   version = params.version.strip(trailing = false, chars = {'v'})
-  size = params.size
+  installedSize = params.installedSize
   arch = params.arch
   depends = params.depends.formatDepends
   desc = params.desc.formatDescription
 
 fixFile(controlFile, package=package, maintainer=maintainer, version=version,
-        size=size, arch=arch, depends=depends, desc=desc)
+        installedSize=installedSize, arch=arch, depends=depends, desc=desc)

--- a/tools/src/replacetool.nim
+++ b/tools/src/replacetool.nim
@@ -31,7 +31,8 @@ proc getCmdOpts(params: seq[string]): Options =
     else:
       assert false
 
-proc replaceTemplate(body, package, maintainer, version, installedSize, arch, depends, desc: string): string =
+proc replaceTemplate(body, package, maintainer, version, installedSize, arch,
+    depends, desc: string): string =
   result =
     body
       .replace("{PACKAGE}", package)
@@ -52,11 +53,14 @@ proc formatDepends(depends: string): string =
     else:
       ""
 
-proc fixFile(file, package, maintainer, version, installedSize, arch, depends, desc: string) =
+proc fixFile(file, package, maintainer, version, installedSize, arch, depends,
+    desc: string) =
   let
     body = readFile(file)
-    fixedBody = replaceTemplate(body, package=package, maintainer=maintainer,
-                                version=version, installedSize=installedSize, arch=arch, depends=depends, desc=desc)
+    fixedBody = replaceTemplate(body, package = package, maintainer = maintainer,
+                                version = version,
+                                installedSize = installedSize, arch = arch,
+                                depends = depends, desc = desc)
   writeFile(file, fixedBody)
 
 let
@@ -73,5 +77,5 @@ let
   depends = params.depends.formatDepends
   desc = params.desc.formatDescription
 
-fixFile(controlFile, package=package, maintainer=maintainer, version=version,
-        installedSize=installedSize, arch=arch, depends=depends, desc=desc)
+fixFile(controlFile, package = package, maintainer = maintainer, version = version,
+        installedSize = installedSize, arch = arch, depends = depends, desc = desc)


### PR DESCRIPTION
when installing a package created by this action i encountered the following warning at the end of the installation process with apt:

`W: Repository is broken: myapp:armhf (= 1.0.0) has no Size information`

so i added support for the [Installed-Size](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-installed-size) field in the package control file

i hope i changed everything correctly and didn't miss anything.