### PR TITLE
Makes all files owned by root

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,6 +217,7 @@ jobs:
           depends: 'libc6 (>= 2.2.1), git'
           arch: 'amd64'
           desc: 'test package'
+          keep_ownership: true
       - name: Install deb package
         run: sudo dpkg -i ./*.deb
       - name: Print deb package information

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ inputs:
       Default is gzip.
     default: 'gzip'
     required: false
+  keep_ownership:
+    description: >
+      If set to true, it creates the package keeping files' owner and group, otherwise they will be assigned to root
+      Default is false.
+    default: 'false'
+    required: false
 ```
 
 ## Output

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,12 @@ inputs:
       Default is gzip.
     default: 'gzip'
     required: false
+  keep_ownership:
+    description: >
+      If set to true, it creates the package keeping files' owner and group, otherwise they will be assigned to root
+      Default is false.
+    default: 'false'
+    required: false
 outputs:
   file_name:
     description: 'File name of resulting .deb file.'

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ outputs:
     description: 'File name of resulting .deb file.'
 runs:
   using: 'docker'
-  image: 'docker://jiro4989/build-deb-action:2.8.1'
+  image: 'docker://jiro4989/build-deb-action:3.0.0'
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 # TODO: update branding if you want.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ -z "$INPUT_INSTALLED_SIZE" ]; then
 fi
 
 case "${INPUT_COMPRESS_TYPE}" in
-  gzip | xz | zstd)
+  gzip | xz | zstd | none)
     # nothing to do
     ;;
   *)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,9 +35,14 @@ cp -r /template/DEBIAN "$INPUT_PACKAGE_ROOT/"
 FIXED_VERSION="$(echo "$INPUT_VERSION" | sed -E 's/^v//')"
 readonly FIXED_VERSION
 
+OWNER="--root-owner-group"
+if [ "${INPUT_KEEP_OWNERSHIP}" = "true" ]; then
+  OWNER=""
+fi
+
 # create deb file
 readonly DEB_FILE="${INPUT_PACKAGE}_${FIXED_VERSION}_${INPUT_ARCH}.deb"
-dpkg-deb -Z"${INPUT_COMPRESS_TYPE}" -b "$INPUT_PACKAGE_ROOT" "$DEB_FILE"
+dpkg-deb -Z"${INPUT_COMPRESS_TYPE}" ${OWNER:+"$OWNER"} --build "$INPUT_PACKAGE_ROOT" "$DEB_FILE"
 
 ls ./*.deb
 echo "file_name=$DEB_FILE" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
When creating a .deb package, all files should be owned by root as implemented in dh_fixperms, unless there is a specific reason to use a different user (e.g. `preinst` script creates that user).