### PR TITLE
Fix ceiling size calculation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ outputs:
     description: 'File name of resulting .deb file.'
 runs:
   using: 'docker'
-  image: 'docker://jiro4989/build-deb-action:2.8.0'
+  image: 'docker://jiro4989/build-deb-action:2.8.1'
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 # TODO: update branding if you want.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
 if [ -z "$INPUT_INSTALLED_SIZE" ]; then
   PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | awk '{print $1}' | head -1 | sed -e 's/^0\+//')"
-  INPUT_INSTALLED_SIZE="$(awk -v size="$PACKAGE_ROOT_SIZE_BYTES" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}')"
+  INPUT_INSTALLED_SIZE="$(( (PACKAGE_ROOT_SIZE_BYTES + 1024 - 1) / 1024 ))"
 fi
 
 case "${INPUT_COMPRESS_TYPE}" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -eux
 INPUT_VERSION="$(echo "$INPUT_VERSION" | sed -E "s,^refs/tags/,,")"
 
 if [ -z "$INPUT_INSTALLED_SIZE" ]; then
-  PACKAGE_ROOT_SIZE_BYTES="$(du -bcs --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | awk '{print $1}' | head -1 | sed -e 's/^0\+//')"
+  PACKAGE_ROOT_SIZE_BYTES="$(du --bytes --summarize --exclude=DEBIAN "$INPUT_PACKAGE_ROOT"/ | awk '{print $1}')"
   INPUT_INSTALLED_SIZE="$(( (PACKAGE_ROOT_SIZE_BYTES + 1024 - 1) / 1024 ))"
 fi
 


### PR DESCRIPTION
With the current implementation, if the size is a multiple of kB, it will add 1.

```
$ awk -v size="1023" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}'
1
$ awk -v size="1024" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}'
2
$ awk -v size="1025" 'BEGIN {print (size/1024)+1}' | awk '{print int($0)}'
2
```

This PR fixes it calculating the correct values:

```
$ echo $(( (1023 + 1024 - 1)/1024 ))
1
$ echo $(( (1024 + 1024 - 1)/1024 ))
1
$ echo $(( (1025 + 1024 - 1)/1024 ))
2
```

source: https://stackoverflow.com/questions/2394988/get-ceiling-integer-from-number-in-linux-bash